### PR TITLE
Fix: Use postcss due to deprecation

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,6 +1,7 @@
 var autoprefixer = require('autoprefixer-core');
 var assign = require('object-assign');
 var minimatch = require('minimatch');
+var postcss = require('postcss');
 
 module.exports = function(str, data){
   var options = this.config.autoprefixer;
@@ -14,7 +15,7 @@ module.exports = function(str, data){
     }
   }
 
-  var result = autoprefixer(options).process(str, {from: data.path});
+  var result = postcss([autoprefixer(options)]).process(str, {from: data.path});
 
   return result.css;
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "autoprefixer-core": "^5.1.1",
     "minimatch": "^2.0.1",
-    "object-assign": "^2.0.0"
+    "object-assign": "^2.0.0",
+    "postcss": "^4.1.11"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
`hexo-autoprefixer` gives me the following warning, so I implemented `postcss` to prevent the deprecation:

> Autoprefixer's process() method is deprecated and will removed in next major release. Use postcss([autoprefixer]).process() instead