### PR TITLE
chore: specify files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.travis.yml
-.idea/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hexo-autoprefixer",
   "version": "2.0.0",
   "description": "Autoprefixer plugin for Hexo.",
-  "main": "index",
+  "main": "index.js",
   "scripts": {
     "eslint": "eslint .",
     "test": "mocha test/index.js",
@@ -12,6 +12,7 @@
     "lib": "./lib"
   },
   "files": [
+    "index.js",
     "lib/"
   ],
   "repository": "hexojs/hexo-autoprefixer",


### PR DESCRIPTION
currently "index.js" is not included when I `npm publish --dry-run`.