### PR TITLE
refactor: async/await

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "hexo",
-  "root": true
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": 2017
+  }
 }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -4,7 +4,7 @@ var autoprefixer = require('autoprefixer');
 var minimatch = require('minimatch');
 var postcss = require('postcss');
 
-module.exports = function(str, data) {
+module.exports = async function(str, data) {
   var options = this.config.autoprefixer;
   var path = data.path;
   var exclude = options.exclude;
@@ -16,11 +16,6 @@ module.exports = function(str, data) {
     }
   }
 
-  const result = postcss([autoprefixer(options)])
-    .process(str, {from: path})
-    .then(output => {
-      return output.css;
-    });
-
-  return result;
+  const result = await postcss([autoprefixer(options)]).process(str, {from: path});
+  return result.css;
 };

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -16,7 +16,11 @@ module.exports = function(str, data) {
     }
   }
 
-  var result = postcss([autoprefixer(options)]).process(str, {from: path});
+  const result = postcss([autoprefixer(options)])
+    .process(str, {from: path})
+    .then(output => {
+      return output.css;
+    });
 
-  return result.css;
+  return result;
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^6.1.0",
     "eslint-config-hexo": "^3.0.0",
     "mocha": "^6.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -1,17 +1,10 @@
 'use strict';
 
-var should = require('chai').should(); // eslint-disable-line
+require('chai').use(require('chai-as-promised')).should();
 var prefixer = require('../lib/filter');
 
-var nonStandards = ['-webkit-', '-moz-'];
-
-function makeCSS(prefix) {
-  var isNS = nonStandards.indexOf(prefix) !== -1;
-
-  return ':%s%d div { color: white;  }'
-    .replace('%s', prefix || '')
-    .replace('%d', isNS ? 'full-screen' : 'fullscreen');
-}
+const unprefixed = 'div { user-select: none; }';
+const prefixed = 'div { -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; }';
 
 describe('hexo-autoprefixer', function() {
   it('should prefix fullscreen with no excludes', function() {
@@ -22,12 +15,11 @@ describe('hexo-autoprefixer', function() {
         }
       }
     };
-    var unprefixed = makeCSS();
     var newCSS = prefixer.call(ctx, unprefixed, {
       path: '/usr/foo/bar/baz.css'
     });
 
-    ['-webkit-', '-moz-', '-ms-'].map(makeCSS).concat(unprefixed).join('\n').should.eql(newCSS);
+    newCSS.should.become(prefixed);
   });
 
   it('should prefix fullscreen with string exclude', function() {
@@ -38,12 +30,11 @@ describe('hexo-autoprefixer', function() {
         }
       }
     };
-    var unprefixed = makeCSS();
     var newCSS = prefixer.call(ctx, unprefixed, {
       path: '/usr/foo/bar/baz.css'
     });
 
-    ['-webkit-', '-moz-', '-ms-'].map(makeCSS).concat(unprefixed).join('\n').should.eql(newCSS);
+    newCSS.should.become(prefixed);
   });
 
   it('should not prefix fullscreen with exclude match', function() {
@@ -54,11 +45,10 @@ describe('hexo-autoprefixer', function() {
         }
       }
     };
-    var unprefixed = makeCSS();
     var newCSS = prefixer.call(ctx, unprefixed, {
       path: '/usr/baz.styl'
     });
 
-    unprefixed.should.eql(newCSS);
+    newCSS.should.become(unprefixed);
   });
 });


### PR DESCRIPTION
Some plugins (e.g. [postcss-normalize](https://github.com/csstools/postcss-normalize)) have started to require async; while autoprefixer currently works fine, it may requires it in future.
This PR is backward-compatible, so there is no breaking change.

`ecmaVersion: 2017` is needed for now until eslint-config-hexo@4 is released (https://github.com/hexojs/eslint-config-hexo/pull/16).

Changed the unit test to use `user-select` as I believe `fullscreen` is no longer prefixed.

https://api.postcss.org/LazyResult.html

Part of https://github.com/hexojs/hexo/issues/3328