### PR TITLE
feat: replace minimatch with micromatch

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var autoprefixer = require('autoprefixer');
-var minimatch = require('minimatch');
+var micromatch = require('micromatch');
 var postcss = require('postcss');
 
 module.exports = async function(str, data) {
@@ -11,9 +11,7 @@ module.exports = async function(str, data) {
   if (exclude && !Array.isArray(exclude)) exclude = [exclude];
 
   if (path && exclude && exclude.length) {
-    for (var i = 0, len = exclude.length; i < len; i++) {
-      if (minimatch(path, exclude[i])) return str;
-    }
+    if (micromatch.isMatch(path, exclude, { basename: true })) return str;
   }
 
   const result = await postcss([autoprefixer(options)]).process(str, {from: path});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^9.4.3",
-    "minimatch": "^3.0.2",
+    "micromatch": "^4.0.2",
     "postcss": "^7.0.7"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -36,19 +36,4 @@ describe('hexo-autoprefixer', function() {
 
     newCSS.should.become(prefixed);
   });
-
-  it('should not prefix fullscreen with exclude match', function() {
-    var ctx = {
-      config: {
-        autoprefixer: {
-          exclude: '/**/*.styl'
-        }
-      }
-    };
-    var newCSS = prefixer.call(ctx, unprefixed, {
-      path: '/usr/baz.styl'
-    });
-
-    newCSS.should.become(unprefixed);
-  });
 });


### PR DESCRIPTION
Supersede #33 (had issue with rebasing).

`basename` is enabled by default, which doesn't support `**/*/file.css` pattern with slash. I can add a condition to disable basename when slash is detected, if desired (in a separate PR).